### PR TITLE
Use fixed-resample for proper input stream resampling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +216,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "duplicate"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,6 +268,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast-interleave"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a7e05e2b3c97d4516fa5c177133f3e4decf9c8318841e1545b260535311e3a5"
+
+[[package]]
+name = "fixed-resample"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8e89e753f8fec9f1158f665d3cc0c96662b7793e1c05095a071ee27a1b122"
+dependencies = [
+ "arrayvec",
+ "fast-interleave",
+ "ringbuf",
+ "rubato",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +320,7 @@ dependencies = [
  "coreaudio-rs",
  "duplicate",
  "env_logger",
+ "fixed-resample",
  "indicatif",
  "libc",
  "log",
@@ -501,6 +532,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
+]
+
+[[package]]
 name = "portable-atomic-util"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,6 +587,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
+name = "realfft"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "390252372b7f2aac8360fc5e72eba10136b166d6faeed97e6d0c8324eb99b2b1"
+dependencies = [
+ "rustfft",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,16 +625,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "ringbuf"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726bb493fe9cac765e8f96a144c3a8396bdf766dedad22e504b70b908dcbceb4"
+dependencies = [
+ "crossbeam-utils",
+ "portable-atomic",
+]
+
+[[package]]
 name = "rtrb"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad8388ea1a9e0ea807e442e8263a699e7edcb320ecbcd21b4fa8ff859acce3ba"
 
 [[package]]
+name = "rubato"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd96992d7e24b3d7f35fdfe02af037a356ac90d41b466945cf3333525a86eea"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "realfft",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustfft"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43806561bc506d0c5d160643ad742e3161049ac01027b5e6d7524091fd401d86"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
+ "version_check",
+]
 
 [[package]]
 name = "serde"
@@ -595,6 +681,12 @@ checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "serde_derive"
@@ -642,6 +734,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,21 +532,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
-name = "primal-check"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
-dependencies = [
- "num-integer",
-]
-
-[[package]]
 name = "portable-atomic-util"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
 ]
 
 [[package]]
@@ -683,12 +683,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strength_reduce"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
-
-[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,6 +698,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,9 +275,9 @@ checksum = "1a7e05e2b3c97d4516fa5c177133f3e4decf9c8318841e1545b260535311e3a5"
 
 [[package]]
 name = "fixed-resample"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8e89e753f8fec9f1158f665d3cc0c96662b7793e1c05095a071ee27a1b122"
+checksum = "39a267bc40fae9b208e2a67a99a8d794caf3a9fe1146d01c147f59bd96257a74"
 dependencies = [
  "arrayvec",
  "fast-interleave",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [dependencies]
 duplicate = "2.0.0"
-fixed-resample = "0.7.1"
+fixed-resample = "0.8.0"
 log = { version = "0.4.27", features = ["kv"] }
 ndarray = "0.16.1"
 oneshot = "0.1.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,12 @@ license = "MIT"
 
 [dependencies]
 duplicate = "2.0.0"
+fixed-resample = "0.7.1"
 log = { version = "0.4.27", features = ["kv"] }
 ndarray = "0.16.1"
 oneshot = "0.1.11"
-thiserror = "2.0.12"
 rtrb = "0.3.2"
+thiserror = "2.0.12"
 
 [dev-dependencies]
 anyhow = "1.0.97"

--- a/examples/duplex.rs
+++ b/examples/duplex.rs
@@ -12,9 +12,9 @@ fn main() -> Result<()> {
     input_config.buffer_size_range = (Some(128), Some(512));
     let mut output_config = output.default_output_config().unwrap();
     output_config.buffer_size_range = (Some(128), Some(512));
+    let duplex_config = DuplexStreamConfig::new(input_config, output_config);
     let stream =
-        duplex::create_duplex_stream(input, input_config, output, output_config, RingMod::new())
-            .unwrap();
+        duplex::create_duplex_stream(input, output, RingMod::new(), duplex_config).unwrap();
     println!("Press Enter to stop");
     std::io::stdin().read_line(&mut String::new())?;
     stream.eject().unwrap();

--- a/examples/loopback.rs
+++ b/examples/loopback.rs
@@ -1,7 +1,6 @@
 use crate::util::meter::PeakMeter;
 use crate::util::AtomicF32;
 use anyhow::Result;
-use interflow::duplex::AudioDuplexCallback;
 use interflow::prelude::*;
 use std::sync::Arc;
 mod util;
@@ -18,14 +17,9 @@ fn main() -> Result<()> {
     input_config.channels = 0b01;
     output_config.channels = 0b11;
     let value = Arc::new(AtomicF32::new(0.));
-    let stream = duplex::create_duplex_stream(
-        input,
-        input_config,
-        output,
-        output_config,
-        Loopback::new(44100., value.clone()),
-    )
-    .unwrap();
+    let config = DuplexStreamConfig::new(input_config, output_config);
+    let stream =
+        create_duplex_stream(input, output, Loopback::new(44100., value.clone()), config).unwrap();
     util::display_peakmeter(value)?;
     stream.eject().unwrap();
     Ok(())

--- a/src/audio_buffer.rs
+++ b/src/audio_buffer.rs
@@ -19,6 +19,10 @@
 //!
 //! The buffers are built on top of ndarray for efficient multidimensional array operations.
 
+use ndarray::{
+    s, Array0, ArrayBase, ArrayView1, ArrayView2, ArrayViewMut1, ArrayViewMut2, AsArray, CowRepr,
+    Data, DataMut, DataOwned, Ix1, Ix2, OwnedArcRepr, OwnedRepr, RawData, RawDataClone, ViewRepr,
+};
 use std::collections::Bound;
 use std::fmt;
 use std::fmt::Formatter;
@@ -593,6 +597,7 @@ impl<S: DataMut<Elem: Sample>> AudioBufferBase<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ndarray::ArrayView1;
 
     fn create_test_buffer() -> AudioBuffer<f32> {
         AudioBuffer::fill_with(2, 4, |ch, i| (ch * 4 + i) as f32)

--- a/src/audio_buffer.rs
+++ b/src/audio_buffer.rs
@@ -174,7 +174,11 @@ impl<S: Data> AudioBufferBase<S> {
         })
     }
 
-    // Iterate over overlapping windows of this audio buffer.
+    /// Iterate over overlapping windows of this audio buffer.
+    ///
+    /// # Arguments
+    ///
+    /// - `size`: Size of the window
     pub fn windows(&self, size: usize) -> impl Iterator<Item = AudioRef<S::Elem>> {
         let mut i = 0;
         std::iter::from_fn(move || {

--- a/src/duplex.rs
+++ b/src/duplex.rs
@@ -422,8 +422,8 @@ pub fn create_duplex_stream<
                 storage_raw: vec![0f32; 8192 * MAX_CHANNELS].into_boxed_slice(),
                 current_samplerate: 0,
                 num_input_channels: config.input.channels.count(),
-                resample_config: fixed_resample::ResamplingChannelConfig {
-                    capacity_seconds: 2.0 * config.target_latency_secs as f64,
+                resample_config: ResamplingChannelConfig {
+                    capacity_seconds: (2.0 * config.target_latency_secs as f64).max(0.5),
                     latency_seconds: config.target_latency_secs as f64,
                     subtract_resampler_delay: true,
                     quality: if config.high_quality_resampling {

--- a/src/duplex.rs
+++ b/src/duplex.rs
@@ -2,7 +2,6 @@
 //!
 //! This module includes a proxy for gathering an input audio stream, and optionally process it to resample it to the
 //! output sample rate.
-use crate::audio_buffer::AudioBuffer;
 use crate::audio_buffer::AudioRef;
 use crate::channel_map::Bitset;
 use crate::{
@@ -47,6 +46,8 @@ pub struct InputProxy {
 }
 
 impl InputProxy {
+    /// Create a new input proxy for transferring an input stream, resample it, and make it available in an output
+    /// stream.
     pub fn new() -> (
         Self,
         rtrb::Producer<u32>,
@@ -142,6 +143,7 @@ impl AudioInputCallback for InputProxy {
 #[error(transparent)]
 /// Represents errors that can occur during duplex stream operations.
 pub enum DuplexCallbackError<InputError, OutputError> {
+    /// No input channels given
     #[error("No input channels given")]
     NoInputChannels,
     /// An error occurred in the input stream
@@ -161,7 +163,7 @@ pub struct DuplexCallback<Callback> {
     storage_raw: Box<[f32]>,
     current_samplerate: u32,
     num_input_channels: usize,
-    pub resample_config: ResamplingChannelConfig,
+    resample_config: ResamplingChannelConfig,
 }
 
 impl<Callback> DuplexCallback<Callback> {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,5 +4,7 @@
 #[cfg(os_wasapi)]
 pub use crate::backends::wasapi::prelude::*;
 pub use crate::backends::*;
-pub use crate::duplex::create_duplex_stream;
+pub use crate::duplex::{
+    create_duplex_stream, AudioDuplexCallback, DuplexStreamConfig, DuplexStreamHandle,
+};
 pub use crate::*;


### PR DESCRIPTION
## Description

Integrates `fixed-resample` to accurately resample the input stream in the duplex system.

Closes #9

Closes #11

## Type of Change

Please delete options that are not relevant.

- [x] Feature addition

## How Has This Been Tested?

Not sure how to test this, but I have added a loopback example to head the input into the output.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Wherever possible, I have added tests that prove my fix is effective or that my feature works. For changes that need to be validated manually (i.e. a new audio driver), use examples that can be run to easily validate them.
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings