### PR TITLE
Allow multiple input channels in CoreAudio

### DIFF
--- a/src/backends/coreaudio.rs
+++ b/src/backends/coreaudio.rs
@@ -196,7 +196,7 @@ impl AudioInputDevice for CoreAudioDevice {
             Element::Input,
         )?;
         Ok(StreamConfig {
-            channels: 0b1, // Hardcoded to mono on non-interleaved inputs
+            channels: 0b11,
             samplerate,
             buffer_size_range: (None, None),
             exclusive: false,


### PR DESCRIPTION
## Description

Fixes an issue in the CoreAudio module where only one channel was supported for audio inputs. 

Switches CoreAudio input streams to interleaved, as only this mode supports multichannel input streams.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

No tests. I ran into this issue trying to create a stereo input stream and realized it was being forced back to mono because of non-interleaved support in CoreAudio being limited to mono.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Wherever possible, I have added tests that prove my fix is effective or that my feature works. For changes that need to be validated manually (i.e. a new audio driver), use examples that can be run to easily validate them.
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings