### PR TITLE
Move rustfmt step to a new CI job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,21 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies (Linux)
+      run: sudo apt install libasound2-dev
+    - name: Install Rust 1.85
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.85
+        default: true
+        override: true
+        components: clippy
+    - name: Run rustfmt
+      run: cargo fmt -- --check
   test:
     strategy:
       fail-fast: false
@@ -22,19 +37,17 @@ jobs:
     - name: Install dependencies (Linux)
       if: ${{matrix.os == 'ubuntu-latest' }}
       run: sudo apt install libasound2-dev
-    - name: Install Rust 1.80
+    - name: Install Rust ${{ matrix.rust }}
       uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
         default: true
         override: true
-        components: rustfmt, clippy
+        components: clippy
     - uses: LoliGothick/clippy-check@master
       continue-on-error: true
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Run rustfmt
-      run: cargo fmt -- --check
     - name: Run clippy
       uses: clechasseur/rs-clippy-check@v4
       with:


### PR DESCRIPTION
## Description

Moves the `rustfmt` step into a separate CI job to avoid duplicate runs and improve the efficiency of the CI pipeline.

Fixes # (issue number)

## Type of Change

Please delete options that are not relevant.

- [x] Code cleanup or refactor

## How Has This Been Tested?

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Wherever possible, I have added tests that prove my fix is effective or that my feature works. For changes that
      need to be validated manually (i.e. a new audio driver), use examples that can be run to easily validate them.
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
