### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+src/backends/alsa @solarliner
+src/backends/wasapi @geom3trik
+src/backends/coreaudio.rs @solarliner


### PR DESCRIPTION
## Description

Adds a [`CODEOWNERS`](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file for marking ownership of implementations, and automatically assigning PR reviews.
