### PR TITLE
Switch DeviceType to bitflags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
 dependencies = [
  "alsa-sys",
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "libc",
 ]
@@ -117,7 +117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
  "annotate-snippets",
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -139,9 +139,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bumpalo"
@@ -475,6 +475,7 @@ version = "0.1.0"
 dependencies = [
  "alsa",
  "anyhow",
+ "bitflags 2.9.0",
  "cfg_aliases",
  "coreaudio-rs",
  "duplicate",
@@ -578,7 +579,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65f3a4b81b2a2d8c7f300643676202debd1b7c929dbf5c9bb89402ea11d19810"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "cc",
  "convert_case",
  "cookie-factory",
@@ -649,7 +650,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "libc",
 ]
@@ -660,7 +661,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -740,7 +741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08e645ba5c45109106d56610b3ee60eb13a6f2beb8b74f8dc8186cf261788dda"
 dependencies = [
  "anyhow",
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "libc",
  "libspa",
  "libspa-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ rust-version = "1.80"
 license = "MIT"
 
 [dependencies]
+bitflags = "2.9.0"
 duplicate = "2.0.0"
 fixed-resample = "0.8.0"
 libspa = { version = "0.8.0", optional = true }

--- a/examples/util/enumerate.rs
+++ b/examples/util/enumerate.rs
@@ -8,8 +8,9 @@ where
     eprintln!("Driver name   : {}", Driver::DISPLAY_NAME);
     eprintln!("Driver version: {}", driver.version()?);
     eprintln!("Default device");
-    for device_type in [DeviceType::Input, DeviceType::Output, DeviceType::Duplex] {
-        eprint!("\t{device_type:?}:\t");
+    for (s, device_type) in [("Input", DeviceType::INPUT), ("Output", DeviceType::OUTPUT)] {
+        let device_type = device_type | DeviceType::PHYSICAL;
+        eprint!("\t{s}:\t");
         if let Some(device) = driver.default_device(device_type)? {
             eprintln!("{}", device.name());
         } else {

--- a/src/backends/alsa/device.rs
+++ b/src/backends/alsa/device.rs
@@ -35,8 +35,8 @@ impl AudioDevice for AlsaDevice {
 
     fn device_type(&self) -> DeviceType {
         match self.direction {
-            alsa::Direction::Playback => DeviceType::Output,
-            alsa::Direction::Capture => DeviceType::Input,
+            alsa::Direction::Capture => DeviceType::PHYSICAL | DeviceType::INPUT,
+            alsa::Direction::Playback => DeviceType::PHYSICAL | DeviceType::OUTPUT,
         }
     }
 
@@ -93,12 +93,7 @@ impl AudioOutputDevice for AlsaDevice {
 
 impl AlsaDevice {
     /// Shortcut constructor for getting ALSA devices directly.
-    pub fn default_device(device_type: DeviceType) -> Result<Option<Self>, alsa::Error> {
-        let direction = match device_type {
-            DeviceType::Input => alsa::Direction::Capture,
-            DeviceType::Output => alsa::Direction::Playback,
-            _ => return Ok(None),
-        };
+    pub fn default_device(direction: alsa::Direction) -> Result<Option<Self>, alsa::Error> {
         let pcm = Rc::new(PCM::new("default", direction, true)?);
         Ok(Some(Self {
             pcm,

--- a/src/backends/alsa/mod.rs
+++ b/src/backends/alsa/mod.rs
@@ -41,11 +41,16 @@ impl AudioDriver for AlsaDriver {
     const DISPLAY_NAME: &'static str = "ALSA";
 
     fn version(&self) -> Result<Cow<str>, Self::Error> {
-        Ok(Cow::Borrowed("ALSA (version unknown)"))
+        Ok(Cow::Borrowed("unknown"))
     }
 
     fn default_device(&self, device_type: DeviceType) -> Result<Option<Self::Device>, Self::Error> {
-        Ok(AlsaDevice::default_device(device_type)?)
+        let direction = match device_type {
+            _ if device_type.is_input() => alsa::Direction::Capture,
+            _ if device_type.is_output() => alsa::Direction::Playback,
+            _ => return Ok(None),
+        };
+        Ok(AlsaDevice::default_device(direction)?)
     }
 
     fn list_devices(&self) -> Result<impl IntoIterator<Item = Self::Device>, Self::Error> {

--- a/src/backends/coreaudio.rs
+++ b/src/backends/coreaudio.rs
@@ -12,7 +12,9 @@ use coreaudio::audio_unit::macos_helpers::{
 };
 use coreaudio::audio_unit::render_callback::{data, Args};
 use coreaudio::audio_unit::{AudioUnit, Element, SampleFormat, Scope, StreamFormat};
-use coreaudio::sys::{kAudioUnitProperty_SampleRate, kAudioUnitProperty_StreamFormat, AudioDeviceID};
+use coreaudio::sys::{
+    kAudioUnitProperty_SampleRate, kAudioUnitProperty_StreamFormat, AudioDeviceID,
+};
 use thiserror::Error;
 
 use crate::audio_buffer::{AudioBuffer, Sample};
@@ -54,7 +56,10 @@ impl AudioDriver for CoreAudioDriver {
         let Some(device_id) = get_default_device_id(device_type.is_input()) else {
             return Ok(None);
         };
-        Ok(Some(CoreAudioDevice::from_id(device_id, device_type.is_input())?))
+        Ok(Some(CoreAudioDevice::from_id(
+            device_id,
+            device_type.is_input(),
+        )?))
     }
 
     fn list_devices(&self) -> Result<impl IntoIterator<Item = Self::Device>, Self::Error> {

--- a/src/backends/coreaudio.rs
+++ b/src/backends/coreaudio.rs
@@ -12,9 +12,7 @@ use coreaudio::audio_unit::macos_helpers::{
 };
 use coreaudio::audio_unit::render_callback::{data, Args};
 use coreaudio::audio_unit::{AudioUnit, Element, SampleFormat, Scope, StreamFormat};
-use coreaudio::sys::{
-    kAudioUnitProperty_SampleRate, kAudioUnitProperty_StreamFormat, AudioDeviceID,
-};
+use coreaudio::sys::{kAudioUnitProperty_SampleRate, kAudioUnitProperty_StreamFormat, AudioDeviceID};
 use thiserror::Error;
 
 use crate::audio_buffer::{AudioBuffer, Sample};
@@ -49,18 +47,14 @@ impl AudioDriver for CoreAudioDriver {
     const DISPLAY_NAME: &'static str = "CoreAudio";
 
     fn version(&self) -> Result<Cow<str>, Self::Error> {
-        Ok(Cow::Borrowed("CoreAudio (version unknown)"))
+        Ok(Cow::Borrowed("unknown"))
     }
 
     fn default_device(&self, device_type: DeviceType) -> Result<Option<Self::Device>, Self::Error> {
-        let is_input = matches!(device_type, DeviceType::Input);
-        let Some(device_id) = get_default_device_id(is_input) else {
+        let Some(device_id) = get_default_device_id(device_type.is_input()) else {
             return Ok(None);
         };
-        Ok(Some(CoreAudioDevice {
-            device_id,
-            device_type,
-        }))
+        Ok(Some(CoreAudioDevice::from_id(device_id, device_type.is_input())?))
     }
 
     fn list_devices(&self) -> Result<impl IntoIterator<Item = Self::Device>, Self::Error> {
@@ -70,7 +64,7 @@ impl AudioDriver for CoreAudioDriver {
                 let audio_ids = get_audio_device_ids_for_scope(scope)?;
                 audio_ids
                     .into_iter()
-                    .map(|id| CoreAudioDevice::from_id(scope, id))
+                    .map(|id| CoreAudioDevice::from_id(id, matches!(scope, Scope::Input)))
                     .collect::<Result<Vec<_>, _>>()
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -86,21 +80,18 @@ pub struct CoreAudioDevice {
 }
 
 impl CoreAudioDevice {
-    fn from_id(scope: Scope, device_id: AudioDeviceID) -> Result<Self, CoreAudioError> {
-        let device_type =
-            Self::scope_to_valid_device_type(scope).ok_or(CoreAudioError::InvalidScope(scope))?;
+    fn from_id(device_id: AudioDeviceID, is_input: bool) -> Result<Self, CoreAudioError> {
+        let is_output = !is_input; // TODO: Interact with CoreAudio directly to be able to work with duplex devices
+        let is_default = get_default_device_id(true) == Some(device_id)
+            || get_default_device_id(false) == Some(device_id);
+        let mut device_type = DeviceType::empty();
+        device_type.set(DeviceType::INPUT, is_input);
+        device_type.set(DeviceType::OUTPUT, is_output);
+        device_type.set(DeviceType::DEFAULT, is_default);
         Ok(Self {
             device_id,
             device_type,
         })
-    }
-
-    fn scope_to_valid_device_type(scope: Scope) -> Option<DeviceType> {
-        match scope {
-            Scope::Input => Some(DeviceType::Input),
-            Scope::Output => Some(DeviceType::Output),
-            _ => None,
-        }
     }
 }
 
@@ -122,7 +113,7 @@ impl AudioDevice for CoreAudioDevice {
     }
 
     fn channel_map(&self) -> impl IntoIterator<Item = Channel> {
-        let is_input = matches!(self.device_type, DeviceType::Input);
+        let is_input = matches!(self.device_type, DeviceType::INPUT);
         let channels = match audio_unit_from_device_id(self.device_id, is_input) {
             Err(err) => {
                 eprintln!("CoreAudio error getting audio unit: {err}");
@@ -244,6 +235,7 @@ impl AudioOutputDevice for CoreAudioDevice {
     }
 }
 
+/// Stream type created by opening up a stream on a [`CoreAudioDevice`].
 pub struct CoreAudioStream<Callback> {
     audio_unit: AudioUnit,
     callback_retrieve: oneshot::Sender<oneshot::Sender<Callback>>,

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -58,7 +58,7 @@ where
     Driver::Device: AudioInputDevice,
 {
     driver
-        .default_device(DeviceType::Input)
+        .default_device(DeviceType::PHYSICAL | DeviceType::INPUT)
         .expect("Audio driver error")
         .expect("No default device found")
 }
@@ -89,7 +89,7 @@ where
     Driver::Device: AudioOutputDevice,
 {
     driver
-        .default_device(DeviceType::Output)
+        .default_device(DeviceType::PHYSICAL | DeviceType::OUTPUT)
         .expect("Audio driver error")
         .expect("No default device found")
 }

--- a/src/backends/pipewire/utils.rs
+++ b/src/backends/pipewire/utils.rs
@@ -19,12 +19,10 @@ fn get_device_type(object: &GlobalObject<&DictRef>) -> Option<DeviceType> {
     }
 
     let media_class = object.props?.get("media.class")?;
-    Some(match (is_input(media_class), is_output(media_class)) {
-        (true, true) => DeviceType::Duplex,
-        (true, _) => DeviceType::Input,
-        (_, true) => DeviceType::Output,
-        _ => return None,
-    })
+    let mut device_type = DeviceType::empty();
+    device_type.set(DeviceType::INPUT, is_input(media_class));
+    device_type.set(DeviceType::OUTPUT, is_output(media_class));
+    Some(device_type)
 }
 
 pub fn get_devices() -> Result<Vec<(u32, DeviceType)>, PipewireError> {
@@ -80,12 +78,4 @@ pub fn get_devices() -> Result<Vec<(u32, DeviceType)>, PipewireError> {
     drop(_listener_core);
     drop(_listener_reg);
     Ok(Rc::into_inner(data).unwrap().into_inner())
-}
-
-pub fn get_default_node_for(device_type: DeviceType) -> u32 {
-    match device_type {
-        DeviceType::Input => 0,
-        DeviceType::Output => 1,
-        DeviceType::Duplex => 2,
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@
 #![warn(missing_docs)]
 
 use std::borrow::Cow;
+use std::fmt;
+use std::fmt::Formatter;
+use bitflags::bitflags;
 
 use crate::audio_buffer::{AudioMut, AudioRef};
 use crate::channel_map::ChannelMap32;
@@ -14,7 +17,31 @@ pub mod duplex;
 pub mod prelude;
 pub mod timestamp;
 
-/// Audio drivers provide access to the inputs and outputs of physical devices.
+bitflags! {
+    /// Represents the types/capabilities of an audio device.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct DeviceType: u32 {
+        /// Device supports audio input.
+        const INPUT = 1 << 0;
+        
+        /// Device supports audio output.
+        const OUTPUT = 1 << 1;
+        
+        /// Physical audio device (hardware).
+        const PHYSICAL = 1 << 2;
+        
+        /// Virtual/software application device.
+        const APPLICATION = 1 << 3;
+        
+        /// This device is set as default
+        const DEFAULT = 1 << 4;
+        
+        /// Device that supports both input and output.
+        const DUPLEX = Self::INPUT.bits() | Self::OUTPUT.bits();
+    }
+}
+
+/// Audio drivers provide access to the inputs and outputs of devices.
 /// Several drivers might provide the same accesses, some sharing it with other applications,
 /// while others work in exclusive mode.
 pub trait AudioDriver {
@@ -38,15 +65,36 @@ pub trait AudioDriver {
     fn list_devices(&self) -> Result<impl IntoIterator<Item = Self::Device>, Self::Error>;
 }
 
-/// Devices are either inputs, outputs, or provide both at the same time.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum DeviceType {
-    /// Device only supports inputs.
-    Input,
-    /// Device only supports outputs.
-    Output,
-    /// Device supports simultaneous inputs and outputs.
-    Duplex,
+impl DeviceType {
+    /// Returns true if this device type has the input capability.
+    pub fn is_input(&self) -> bool {
+        self.contains(Self::INPUT)
+    }
+    
+    /// Returns true if this device type has the output capability.
+    pub fn is_output(&self) -> bool {
+        self.contains(Self::OUTPUT)
+    }
+    
+    /// Returns true if this device type is a physical device.
+    pub fn is_physical(&self) -> bool {
+        self.contains(Self::PHYSICAL)
+    }
+    
+    /// Returns true if this device type is an application/virtual device.
+    pub fn is_application(&self) -> bool {
+        self.contains(Self::APPLICATION)
+    }
+    
+    /// Returns true if this device is set as default
+    pub fn is_default(&self) -> bool {
+        self.contains(Self::DEFAULT)
+    }
+    
+    /// Returns true if this device type supports both input and output.
+    pub fn is_duplex(&self) -> bool {
+        self.contains(Self::DUPLEX)
+    }
 }
 
 /// Configuration for an audio stream.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
 
+use bitflags::bitflags;
 use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Formatter;
-use bitflags::bitflags;
 
 use crate::audio_buffer::{AudioMut, AudioRef};
 use crate::channel_map::ChannelMap32;
@@ -23,19 +23,19 @@ bitflags! {
     pub struct DeviceType: u32 {
         /// Device supports audio input.
         const INPUT = 1 << 0;
-        
+
         /// Device supports audio output.
         const OUTPUT = 1 << 1;
-        
+
         /// Physical audio device (hardware).
         const PHYSICAL = 1 << 2;
-        
+
         /// Virtual/software application device.
         const APPLICATION = 1 << 3;
-        
+
         /// This device is set as default
         const DEFAULT = 1 << 4;
-        
+
         /// Device that supports both input and output.
         const DUPLEX = Self::INPUT.bits() | Self::OUTPUT.bits();
     }
@@ -70,27 +70,27 @@ impl DeviceType {
     pub fn is_input(&self) -> bool {
         self.contains(Self::INPUT)
     }
-    
+
     /// Returns true if this device type has the output capability.
     pub fn is_output(&self) -> bool {
         self.contains(Self::OUTPUT)
     }
-    
+
     /// Returns true if this device type is a physical device.
     pub fn is_physical(&self) -> bool {
         self.contains(Self::PHYSICAL)
     }
-    
+
     /// Returns true if this device type is an application/virtual device.
     pub fn is_application(&self) -> bool {
         self.contains(Self::APPLICATION)
     }
-    
+
     /// Returns true if this device is set as default
     pub fn is_default(&self) -> bool {
         self.contains(Self::DEFAULT)
     }
-    
+
     /// Returns true if this device type supports both input and output.
     pub fn is_duplex(&self) -> bool {
         self.contains(Self::DUPLEX)


### PR DESCRIPTION
## Description

Changes the `DeviceType` type from a straight enum to a `bitflags` type to be able to specify overlapping properties. Also introduces properties for specifying if the devices are set as default, if they're physical or application devices (for backends that allow enumerating application or virtual sources and sinks)

## Type of Change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code cleanup or refactor

## How Has This Been Tested?

Ran the examples on macOS and Linux (missing Windows)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Wherever possible, I have added tests that prove my fix is effective or that my feature works. For changes that
      need to be validated manually (i.e. a new audio driver), use examples that can be run to easily validate them.
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
