### PR TITLE
fix(pipewire): attach stream to the selected device

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ libc = "0.2.174"
 libspa = { version = "0.8.0", optional = true }
 libspa-sys = { version = "0.8.0", optional = true }
 nix = "0.30.1"
-pipewire = { version = "0.8.0", optional = true }
+pipewire = { version = "0.8.0", optional = true, features = ["v0_3_44"] }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 coreaudio-rs = "0.13.0"

--- a/src/backends/pipewire/device.rs
+++ b/src/backends/pipewire/device.rs
@@ -13,6 +13,7 @@ use std::rc::Rc;
 pub struct PipewireDevice {
     pub(super) target_node: Option<u32>,
     pub device_type: DeviceType,
+    pub object_serial: Option<String>,
     pub stream_name: Cow<'static, str>,
 }
 
@@ -67,7 +68,12 @@ impl AudioInputDevice for PipewireDevice {
         stream_config: StreamConfig,
         callback: Callback,
     ) -> Result<Self::StreamHandle<Callback>, Self::Error> {
-        StreamHandle::new_input(&self.stream_name, stream_config, callback)
+        StreamHandle::new_input(
+            self.object_serial.clone(),
+            &self.stream_name,
+            stream_config,
+            callback,
+        )
     }
 }
 
@@ -88,7 +94,12 @@ impl AudioOutputDevice for PipewireDevice {
         stream_config: StreamConfig,
         callback: Callback,
     ) -> Result<Self::StreamHandle<Callback>, Self::Error> {
-        StreamHandle::new_output(&self.stream_name, stream_config, callback)
+        StreamHandle::new_output(
+            self.object_serial.clone(),
+            &self.stream_name,
+            stream_config,
+            callback,
+        )
     }
 }
 

--- a/src/backends/pipewire/driver.rs
+++ b/src/backends/pipewire/driver.rs
@@ -23,6 +23,7 @@ impl AudioDriver for PipewireDriver {
         Ok(Some(PipewireDevice {
             target_node: None,
             device_type,
+            object_serial: None,
             stream_name: Cow::Borrowed("Interflow stream"),
         }))
     }
@@ -30,9 +31,10 @@ impl AudioDriver for PipewireDriver {
     fn list_devices(&self) -> Result<impl IntoIterator<Item = Self::Device>, Self::Error> {
         Ok(utils::get_devices()?
             .into_iter()
-            .map(|(id, device_type)| PipewireDevice {
+            .map(|(id, device_type, object_serial)| PipewireDevice {
                 target_node: Some(id),
                 device_type,
+                object_serial: Some(object_serial),
                 stream_name: Cow::Borrowed("Interflow stream"),
             }))
     }

--- a/src/backends/pipewire/utils.rs
+++ b/src/backends/pipewire/utils.rs
@@ -25,7 +25,12 @@ fn get_device_type(object: &GlobalObject<&DictRef>) -> Option<DeviceType> {
     Some(device_type)
 }
 
-pub fn get_devices() -> Result<Vec<(u32, DeviceType)>, PipewireError> {
+fn get_device_object_serial(object: &GlobalObject<&DictRef>) -> Option<String> {
+    let object_serial = object.props?.get("object.serial")?;
+    Some(object_serial.to_owned())
+}
+
+pub fn get_devices() -> Result<Vec<(u32, DeviceType, String)>, PipewireError> {
     let mainloop = MainLoop::new(None)?;
     let context = Context::new(&mainloop)?;
     let core = context.connect(None)?;
@@ -65,8 +70,13 @@ pub fn get_devices() -> Result<Vec<(u32, DeviceType)>, PipewireError> {
                     global.type_,
                     global.version
                 );
-                if let Some(device_type) = get_device_type(global) {
-                    data.borrow_mut().push((global.id, device_type));
+
+                let device_type = get_device_type(global);
+                let object_serial = get_device_object_serial(global);
+
+                if let (Some(device_type), Some(object_serial)) = (device_type, object_serial) {
+                    data.borrow_mut()
+                        .push((global.id, device_type, object_serial));
                 }
             }
         })


### PR DESCRIPTION
## Description

This change attaches the pipewire streams to the device that was used to create them. Without this they get attached to the default device.

Fixes #69 

The PR uses the [`target.object`](https://docs.pipewire.org/group__pw__keys.html#ga7983296afaca4d7edac60714fa92565b) property, which can be either the object name or the object serial. I opted for the serial, which looks like a more robust choice. Unfortunately, this property requires pipewire 0.3.44, see below.

There is also a [`node.target`](https://docs.pipewire.org/page_man_pipewire-props_7.html) property but it's marked as deprecated. Still, maybe we could fall back to using this one prior to `0.3.44`?

## Type of Change

Requires pipewire feature `v0_3_44`, which is technically a breaking change if some users are running a pipewire version that's more than 3 years old. https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/0.3.44

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

I am not sure how to test device selection automatically, so I have only done manual testing. 

- [x] I modified some examples locally to use selected instead of default devices and ran them with `pipewire` feature enabled. I observed the stream attachment with `pw-top`.
- [x] We have a production use case with machines having many audio devices and using multiple input and output streams. With the code in this PR all of the streams are being attached correctly.
- [ ] It should be possible to use pipewire introspection to check the streams are attached correctly, let me know if you would like me to attempt it. But it would only be a useful test if there is a non-default device to select.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Wherever possible, I have added tests that prove my fix is effective or that my feature works. For changes that
      need to be validated manually (i.e. a new audio driver), use examples that can be run to easily validate them.
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## Screenshots (if appropriate):

## Additional Notes:

Add any additional notes about the PR here.
