### PR TITLE
Fix pipewire buffer processing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ libc = "0.2.174"
 libspa = { version = "0.8.0", optional = true }
 libspa-sys = { version = "0.8.0", optional = true }
 nix = "0.30.1"
-pipewire = { version = "0.8.0", optional = true, features = ["v0_3_49"] }
+pipewire = { version = "0.8.0", optional = true, features = ["v0_3_45"] }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 coreaudio-rs = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ libc = "0.2.174"
 libspa = { version = "0.8.0", optional = true }
 libspa-sys = { version = "0.8.0", optional = true }
 nix = "0.30.1"
-pipewire = { version = "0.8.0", optional = true, features = ["v0_3_44"] }
+pipewire = { version = "0.8.0", optional = true, features = ["v0_3_49"] }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 coreaudio-rs = "0.13.0"

--- a/src/backends/pipewire/stream.rs
+++ b/src/backends/pipewire/stream.rs
@@ -9,6 +9,7 @@ use crate::{
 use libspa::buffer::Data;
 use libspa::param::audio::{AudioFormat, AudioInfoRaw};
 use libspa::pod::Pod;
+use libspa::utils::Direction;
 use libspa_sys::{SPA_PARAM_EnumFormat, SPA_TYPE_OBJECT_Format};
 use pipewire::context::Context;
 use pipewire::keys;
@@ -195,25 +196,49 @@ impl<Callback: 'static + Send> StreamHandle<Callback> {
                         return;
                     }
                     if let Some(mut buffer) = stream.dequeue_buffer() {
-                        let datas = buffer.datas_mut();
-                        log::debug!("Datas: len={}", datas.len());
-                        let Some(min_frames) = datas
-                            .iter_mut()
-                            .filter_map(|d| d.data().map(|d| d.len() / size_of::<f32>()))
-                            .min()
-                        else {
-                            log::warn!("No datas available");
-                            return;
-                        };
-                        let frames = min_frames.min(MAX_FRAMES);
+                        if direction == Direction::Input {
+                            let datas = buffer.datas_mut();
+                            log::debug!("Datas: len={}", datas.len());
 
-                        let frames = process_frames(datas, inner, channels, frames);
+                            let chunk_sizes: Vec<_> = datas
+                                .iter()
+                                .map(|d| d.chunk().size() as usize / size_of::<f32>())
+                                .collect();
 
-                        for data in datas.iter_mut() {
-                            let chunk = data.chunk_mut();
-                            *chunk.offset_mut() = 0;
-                            *chunk.stride_mut() = size_of::<f32>() as _;
-                            *chunk.size_mut() = (size_of::<f32>() * frames) as _;
+                            let Some(min_samples) = chunk_sizes.iter().min() else {
+                                log::warn!("No datas available");
+                                return;
+                            };
+
+                            let min_frames = min_samples / channels;
+                            let frames = min_frames.min(MAX_FRAMES);
+                            process_frames(datas, inner, channels, frames);
+                        }
+
+                        if direction == Direction::Output {
+                            let requested_frames = buffer.requested() as usize;
+                            if requested_frames == 0 {
+                                return;
+                            }
+
+                            let datas = buffer.datas_mut();
+                            log::debug!("Datas: len={}", datas.len());
+                            let Some(_min_frames) = datas
+                                .iter_mut()
+                                .filter_map(|d| d.data().map(|d| d.len() / size_of::<f32>()))
+                                .min()
+                            else {
+                                log::warn!("No datas available");
+                                return;
+                            };
+
+                            let frames = process_frames(datas, inner, channels, requested_frames);
+                            for data in datas.iter_mut() {
+                                let chunk = data.chunk_mut();
+                                *chunk.offset_mut() = 0;
+                                *chunk.stride_mut() = size_of::<f32>() as _;
+                                *chunk.size_mut() = (size_of::<f32>() * frames) as _;
+                            }
                         }
                     } else {
                         log::warn!("No buffer available");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ pub struct StreamConfig {
     /// order does not matter.
     pub channels: ChannelMap32,
     /// Range of preferential buffer sizes, in units of audio samples per channel.
-    /// The library will make a bast-effort attempt at honoring this setting, and in future versions
+    /// The library will make a best-effort attempt at honoring this setting, and in future versions
     /// may provide additional buffering to ensure it, but for now you should not make assumptions
     /// on buffer sizes based on this setting.
     pub buffer_size_range: (Option<usize>, Option<usize>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,9 +110,10 @@ pub struct StreamConfig {
     /// the audio buffers. For other drivers, only the number of requested channels is used, and
     /// order does not matter.
     pub channels: ChannelMap32,
-    /// Range of preferential buffer sizes. The library will make a bast-effort attempt at
-    /// honoring this setting, and in future versions may provide additional buffering to ensure
-    /// it, but for now you should not make assumptions on buffer sizes based on this setting.
+    /// Range of preferential buffer sizes, in units of audio samples per channel.
+    /// The library will make a bast-effort attempt at honoring this setting, and in future versions
+    /// may provide additional buffering to ensure it, but for now you should not make assumptions
+    /// on buffer sizes based on this setting.
     pub buffer_size_range: (Option<usize>, Option<usize>),
     /// Whether the device should be exclusively held (meaning no other application can open the
     /// same device).


### PR DESCRIPTION
## Description

This is a more intense PR that attempts to fix several issues with pipewire buffer processing. It does multiple things to solve multiple issues and it might be controversial, so please consider it just a conversation starting point, I'd be happy to cut it up into multiple PRs and/or use alternative approaches, whatever is deemed best.

- Chunk sizes were not respected and the whole scratch buffer was used instead.
  - On the input side pipewire tells us how much data was captured and we should respect that. I _think_ we should also not write into the chunk data here (that's reserved for telling pipewire how much data _we_ are providing on the output side below).
  - On the output side there is `Buffer::requested()` API to tell us how much data is expected in this period but it's only available in 0.3.49. This is higher than the Ubuntu LTS version (0.3.48), so we should find a fall back when using an older version. There are many other things we could do here: use the sizes that the user provided in the stream config or query the device properties for some defaults.
- Putting multiple chunks to and from the scratch buffer did not work as expected.
  - I believe the old frame processor wrongly reordered data in case of multiple channels and multiple chunks. I solved it by switching to interleaved sampling (`F32LE`), which trivializes the problem: in this case the chunks can simply be joined. But it would also be possible to keep the non-interleaved sampling (`F32P`) and reorder the channel data correctly.
- Removed from this PR but closely related to the above: we would like to use fixed buffer sizes for arcane AEC webrtc processor reasons. I found that it is possible to use [node.force-quantum](https://docs.pipewire.org/group__pw__keys.html#gaa50ce0bca22904a417a4e9d05f8face6) to achieve this but I do not know if this is the correct way to approach things. I suppose there might be softer ways to tell pipewire that you'd like to use buffer sizes in a given range.

## Type of Change

Using the `Buffer::requested()` API is a breaking change but maybe it's not strictly necessary. The rest of the PR should be non-breaking.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] The `sine_wave` example did not work for me as expected, it was choppy and the callback was only called few times a second (presumably because the 8192 scratch buffer was provided every time, so pipewire decided 6 calls are enough to get the required 48k ~ 6 * 4192 samples). With this PR it's using buffer sizes proportional to the default device quantization (1024 in my case), gets called roughly every 20ms, and the expected sine wave sound is produced.
- [ ] Adding callback timestamp info to the `input` example reveals that it suffered from similar problems, it was only called few times a second. I haven't recorded audio samples but I suspect they would have been garbled. After this PR audio capture works fine on a variety of devices (mics and capture card).
- [ ] The processing of multiple chunks is harder to test, pipewire typically uses just 1 chunk, but I did run into it on some devices and before this PR I got first crashes and then garbled input/output, with the PR in its current form it seems to work fine.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Wherever possible, I have added tests that prove my fix is effective or that my feature works. For changes that
      need to be validated manually (i.e. a new audio driver), use examples that can be run to easily validate them.
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings

## Screenshots (if appropriate):

## Additional Notes:

Add any additional notes about the PR here.
