### PR TITLE
Add `PipewireDevice::with_stream_properties()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,3 +70,8 @@ path = "examples/enumerate_wasapi.rs"
 name = "enumerate_pipewire"
 path = "examples/enumerate_pipewire.rs"
 required-features = ["pipewire"]
+
+[[example]]
+name = "sine_wave_pipewire"
+path = "examples/sine_wave_pipewire.rs"
+required-features = ["pipewire"]

--- a/examples/sine_wave_pipewire.rs
+++ b/examples/sine_wave_pipewire.rs
@@ -1,0 +1,26 @@
+use interflow::prelude::*;
+use util::sine::SineWave;
+
+mod util;
+
+#[cfg(all(os_pipewire, feature = "pipewire"))]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use interflow::prelude::pipewire::driver::PipewireDriver;
+
+    env_logger::init();
+
+    let driver = PipewireDriver::new()?;
+    let mut device = driver.default_device(DeviceType::OUTPUT)?.unwrap();
+    println!("Using device {}", device.name());
+
+    let config = device.default_output_config()?;
+    device.with_stream_name("Interflow sine wave");
+    let properties = [("node.custom-property".to_owned(), "interflow".to_owned())].into();
+    device.with_stream_properties(properties);
+    let stream = device.create_output_stream(config, SineWave::new(440.0))?;
+
+    println!("Press Enter to stop");
+    std::io::stdin().read_line(&mut String::new())?;
+    stream.eject().unwrap();
+    Ok(())
+}

--- a/examples/sine_wave_pipewire.rs
+++ b/examples/sine_wave_pipewire.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let config = device.default_output_config()?;
     device.with_stream_name("Interflow sine wave");
-    let properties = [("node.custom-property".to_owned(), "interflow".to_owned())].into();
+    let properties = [("node.custom-property".into(), "interflow".into())].into();
     device.with_stream_properties(properties);
     let stream = device.create_output_stream(config, SineWave::new(440.0))?;
 

--- a/src/backends/pipewire/device.rs
+++ b/src/backends/pipewire/device.rs
@@ -8,13 +8,16 @@ use pipewire::context::Context;
 use pipewire::main_loop::MainLoop;
 use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
 use std::rc::Rc;
 
 pub struct PipewireDevice {
     pub(super) target_node: Option<u32>,
     pub device_type: DeviceType,
     pub object_serial: Option<String>,
+    // TODO: it would be better to put these fields into a stream builder struct.
     pub stream_name: Cow<'static, str>,
+    pub stream_properties: HashMap<String, String>,
 }
 
 impl AudioDevice for PipewireDevice {
@@ -72,6 +75,7 @@ impl AudioInputDevice for PipewireDevice {
             self.object_serial.clone(),
             &self.stream_name,
             stream_config,
+            self.stream_properties.clone(),
             callback,
         )
     }
@@ -98,14 +102,25 @@ impl AudioOutputDevice for PipewireDevice {
             self.object_serial.clone(),
             &self.stream_name,
             stream_config,
+            self.stream_properties.clone(),
             callback,
         )
     }
 }
 
 impl PipewireDevice {
+    /// Name to be used for the next stream created with [`AudioInputDevice::create_input_stream()`]
+    /// or [`AudioOutputDevice::create_output_stream()`].
     pub fn with_stream_name(&mut self, name: impl Into<Cow<'static, str>>) {
         self.stream_name = name.into();
+    }
+
+    /// Properties for the next stream created with [`AudioInputDevice::create_input_stream()`]
+    /// or [`AudioOutputDevice::create_output_stream()`].
+    /// These correspond to [`pipewire::properties::Properties`] but need to be passed in a
+    /// [`HashMap`] as the pipewire properties are not `Send`.
+    pub fn with_stream_properties(&mut self, properties: HashMap<String, String>) {
+        self.stream_properties = properties
     }
 }
 

--- a/src/backends/pipewire/device.rs
+++ b/src/backends/pipewire/device.rs
@@ -15,9 +15,8 @@ pub struct PipewireDevice {
     pub(super) target_node: Option<u32>,
     pub device_type: DeviceType,
     pub object_serial: Option<String>,
-    // TODO: it would be better to put these fields into a stream builder struct.
     pub stream_name: Cow<'static, str>,
-    pub stream_properties: HashMap<String, String>,
+    pub stream_properties: HashMap<Vec<u8>, Vec<u8>>,
 }
 
 impl AudioDevice for PipewireDevice {
@@ -119,7 +118,7 @@ impl PipewireDevice {
     /// or [`AudioOutputDevice::create_output_stream()`].
     /// These correspond to [`pipewire::properties::Properties`] but need to be passed in a
     /// [`HashMap`] as the pipewire properties are not `Send`.
-    pub fn with_stream_properties(&mut self, properties: HashMap<String, String>) {
+    pub fn with_stream_properties(&mut self, properties: HashMap<Vec<u8>, Vec<u8>>) {
         self.stream_properties = properties
     }
 }

--- a/src/backends/pipewire/driver.rs
+++ b/src/backends/pipewire/driver.rs
@@ -3,6 +3,7 @@ use crate::backends::pipewire::device::PipewireDevice;
 use crate::backends::pipewire::utils;
 use crate::{AudioDriver, DeviceType};
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::marker::PhantomData;
 
 pub struct PipewireDriver {
@@ -25,6 +26,7 @@ impl AudioDriver for PipewireDriver {
             device_type,
             object_serial: None,
             stream_name: Cow::Borrowed("Interflow stream"),
+            stream_properties: HashMap::new(),
         }))
     }
 
@@ -36,6 +38,7 @@ impl AudioDriver for PipewireDriver {
                 device_type,
                 object_serial: Some(object_serial),
                 stream_name: Cow::Borrowed("Interflow stream"),
+                stream_properties: HashMap::new(),
             }))
     }
 }

--- a/src/backends/pipewire/stream.rs
+++ b/src/backends/pipewire/stream.rs
@@ -147,7 +147,7 @@ impl<Callback: 'static + Send> StreamHandle<Callback> {
         device_object_serial: Option<String>,
         name: String,
         mut config: StreamConfig,
-        user_properties: HashMap<String, String>,
+        user_properties: HashMap<Vec<u8>, Vec<u8>>,
         callback: Callback,
         direction: pipewire::spa::utils::Direction,
         process_frames: impl Fn(&mut [Data], &mut StreamInner<Callback>, usize, usize) -> usize
@@ -262,7 +262,7 @@ impl<Callback: 'static + Send + AudioInputCallback> StreamHandle<Callback> {
         device_object_serial: Option<String>,
         name: impl ToString,
         config: StreamConfig,
-        properties: HashMap<String, String>,
+        properties: HashMap<Vec<u8>, Vec<u8>>,
         callback: Callback,
     ) -> Result<Self, PipewireError> {
         Self::create_stream(
@@ -304,7 +304,7 @@ impl<Callback: 'static + Send + AudioOutputCallback> StreamHandle<Callback> {
         device_object_serial: Option<String>,
         name: impl ToString,
         config: StreamConfig,
-        properties: HashMap<String, String>,
+        properties: HashMap<Vec<u8>, Vec<u8>>,
         callback: Callback,
     ) -> Result<Self, PipewireError> {
         Self::create_stream(

--- a/src/backends/pipewire/stream.rs
+++ b/src/backends/pipewire/stream.rs
@@ -13,8 +13,9 @@ use libspa_sys::{SPA_PARAM_EnumFormat, SPA_TYPE_OBJECT_Format};
 use pipewire::context::Context;
 use pipewire::keys;
 use pipewire::main_loop::{MainLoop, WeakMainLoop};
-use pipewire::properties::properties;
+use pipewire::properties::Properties;
 use pipewire::stream::{Stream, StreamFlags};
+use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Formatter;
 use std::thread::JoinHandle;
@@ -146,6 +147,7 @@ impl<Callback: 'static + Send> StreamHandle<Callback> {
         device_object_serial: Option<String>,
         name: String,
         mut config: StreamConfig,
+        user_properties: HashMap<String, String>,
         callback: Callback,
         direction: pipewire::spa::utils::Direction,
         process_frames: impl Fn(&mut [Data], &mut StreamInner<Callback>, usize, usize) -> usize
@@ -161,18 +163,21 @@ impl<Callback: 'static + Send> StreamHandle<Callback> {
             let channels = config.channels.count();
             let channels_str = channels.to_string();
 
-            let mut props = properties! {
-                *keys::MEDIA_TYPE => "Audio",
-                *keys::MEDIA_ROLE => "Music",
-                *keys::MEDIA_CATEGORY => get_category(direction),
-                *keys::AUDIO_CHANNELS => channels_str,
-            };
-
-            if let Some(device_object_serial) = device_object_serial {
-                props.insert(*keys::TARGET_OBJECT, device_object_serial);
+            let mut properties = Properties::new();
+            for (key, value) in user_properties {
+                properties.insert(key, value);
             }
 
-            let stream = Stream::new(&core, &name, props)?;
+            properties.insert(*keys::MEDIA_TYPE, "Audio");
+            properties.insert(*keys::MEDIA_ROLE, "Music");
+            properties.insert(*keys::MEDIA_CATEGORY, get_category(direction));
+            properties.insert(*keys::AUDIO_CHANNELS, channels_str);
+
+            if let Some(device_object_serial) = device_object_serial {
+                properties.insert(*keys::TARGET_OBJECT, device_object_serial);
+            }
+
+            let stream = Stream::new(&core, &name, properties)?;
             config.samplerate = config.samplerate.round();
             let _listener = stream
                 .add_local_listener_with_user_data(StreamInner {
@@ -257,12 +262,14 @@ impl<Callback: 'static + Send + AudioInputCallback> StreamHandle<Callback> {
         device_object_serial: Option<String>,
         name: impl ToString,
         config: StreamConfig,
+        properties: HashMap<String, String>,
         callback: Callback,
     ) -> Result<Self, PipewireError> {
         Self::create_stream(
             device_object_serial,
             name.to_string(),
             config,
+            properties,
             callback,
             pipewire::spa::utils::Direction::Input,
             |datas, inner, channels, frames| {
@@ -297,12 +304,14 @@ impl<Callback: 'static + Send + AudioOutputCallback> StreamHandle<Callback> {
         device_object_serial: Option<String>,
         name: impl ToString,
         config: StreamConfig,
+        properties: HashMap<String, String>,
         callback: Callback,
     ) -> Result<Self, PipewireError> {
         Self::create_stream(
             device_object_serial,
             name.to_string(),
             config,
+            properties,
             callback,
             pipewire::spa::utils::Direction::Output,
             |datas, inner, channels, frames| {


### PR DESCRIPTION
## Description

Discussed in https://github.com/SolarLiner/interflow/pull/78#issuecomment-3061191242: it's desirable to make pipewire stream properties configurable.

This PR adds a new method that accepts a `HashMap<String, String>`. It cannot use `Properties` as those are not `Send` and we need to pass the object into the stream. But many other types are possible (`BTreeMap` is an obvious alternative), so let me know if you'd prefer a different API.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests you added or ran to verify your changes. Provide instructions so we can reproduce. Try to run
on as many audio drivers as you can get your hands on.

- [x] I added a new example `sine_wave_pipewire` that uses the new API to set a custom property. This can then be observed with `wpctl`.
- [x] I ran `sine_wave` and `input` examples to make sure audio still works and the core stream properties continue to be set.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Wherever possible, I have added tests that prove my fix is effective or that my feature works. For changes that
      need to be validated manually (i.e. a new audio driver), use examples that can be run to easily validate them.
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## Screenshots (if appropriate):

## Additional Notes:

Add any additional notes about the PR here.
